### PR TITLE
fix credentials error for aws-sdk

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,8 +138,10 @@ class ServerlessDynamodbLocal {
                 });
 			}else{
 				dynamoOptions = {
-                    endpoint: 'http://localhost:' + port,
-                    region: 'localhost'
+			endpoint: 'http://localhost:' + port,
+			region: 'localhost',
+			accessKeyId: '1234',
+			secretAccessKey: '1234'
                 };
 			}		
 			return {


### PR DESCRIPTION
An error saying "Could not load credentials from any providers error" happens when trying to use migrate with no default aws-sdk profile set.
This is a quick fix for this kind of error, which doesn't make the user use a default aws-sdk profile.